### PR TITLE
Revert "v4l2: Stream CAPTURE queue during initialisation"

### DIFF
--- a/media/gpu/v4l2/v4l2_video_decoder.cc
+++ b/media/gpu/v4l2/v4l2_video_decoder.cc
@@ -32,7 +32,6 @@ constexpr size_t kInputBufferMaxSizeFor1080p = 1024 * 1024;
 // Input bitstream buffer size for up to 4k streams.
 constexpr size_t kInputBufferMaxSizeFor4k = 4 * kInputBufferMaxSizeFor1080p;
 constexpr size_t kNumInputBuffers = 16;
-constexpr size_t kNumOutputBuffers = 16;
 
 // Input format V4L2 fourccs this class supports.
 constexpr uint32_t kSupportedInputFourccs[] = {
@@ -247,17 +246,9 @@ void V4L2VideoDecoder::Initialize(const VideoDecoderConfig& config,
     return;
   }
 
-  if (output_queue_->AllocateBuffers(kNumOutputBuffers, V4L2_MEMORY_DMABUF) == 0) {
-    VLOGF(1) << "Failed to allocate output buffer.";
-    std::move(init_cb).Run(StatusCode::kV4l2FailedResourceAllocation);
-    return;
-  }
-
   // Start streaming input queue and polling. This is required for the stateful
   // decoder, and doesn't hurt for the stateless one.
-  // Start streaming output queue for RPi (bbc/chromium #11)
-  // TODO(ewanr): Remove allocate/stream for output queue once #11 is fixed
-  if (!StartStreamV4L2Queue(true)) {
+  if (!StartStreamV4L2Queue(false)) {
     VLOGF(1) << "Failed to start streaming.";
     std::move(init_cb).Run(StatusCode::kV4L2FailedToStartStreamQueue);
     return;

--- a/media/gpu/v4l2/v4l2_video_decoder_backend_stateful.cc
+++ b/media/gpu/v4l2/v4l2_video_decoder_backend_stateful.cc
@@ -565,10 +565,7 @@ void V4L2StatefulVideoDecoderBackend::ChangeResolution() {
 
   // ...that is, unless we are not streaming yet, in which case the resolution
   // change can take place immediately.
-  // Output queue will be streaming during initialisation on the RPi, so start
-  // the resolution change anyway (bbc/chromium #11)
-  // TODO(ewanr): Uncomment once #11 is fixed
-  // if (!output_queue_->IsStreaming())
+  if (!output_queue_->IsStreaming())
     std::move(resolution_change_cb_).Run();
 }
 


### PR DESCRIPTION
Commit 7a36a4225fe022cf72a0e7c70036c4c5ff73f547 is no longer required as https://github.com/bbc/linux/commit/7792edd663040e7751375a36b16092b6aea28299 fixes #11.

Resolves: #11, #25, #29, #32